### PR TITLE
i mustn't tell lies

### DIFF
--- a/lib/database.ex
+++ b/lib/database.ex
@@ -56,13 +56,11 @@ defmodule ExFlux.Database do
         )
       end
 
-      @spec database_name(prov :: String.t()) :: String.t()
-      defp database_name(prov) when is_binary(prov), do: prov
-
-      defp database_name(_prov) do
+      @spec database_name(prov :: String.t() | nil) :: String.t()
+      defp database_name(prov) do
         @otp_app
         |> Application.get_env(__MODULE__, [])
-        |> Keyword.get(:database)
+        |> Keyword.get(:database, prov)
       end
 
       defoverridable child_spec: 1

--- a/lib/database/supervisor.ex
+++ b/lib/database/supervisor.ex
@@ -23,7 +23,7 @@ defmodule ExFlux.Database.Supervisor do
     `:gen_udp`, defaults to `[:binary, {:active, false}]` since we are
     exclusively writing
   * `:host` - hostname of the influxdb server
-  * `:port` - the port number influxdb is listening on for this particular
+  * `:udp_port` - the port number influxdb is listening on for this particular
     database
   """
 


### PR DESCRIPTION
dialyzer doesn't like dealing with optional `__using__` opts